### PR TITLE
Add sample Telegram weather bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,42 @@
-# chat_bot
+# Telegram Weather Bot
+
+Этот репозиторий содержит пример Telegram-бота, который выдаёт прогноз погоды на неделю по данным Яндекс.Погоды.
+
+## Настройка
+
+1. Сгенерируйте токен Telegram-бота через [@BotFather](https://t.me/BotFather).
+2. Получите ключ API Яндекс.Погоды в [личном кабинете разработчика](https://developer.tech.yandex.ru/).
+3. Экспортируйте переменные окружения `TELEGRAM_TOKEN` и `YANDEX_API_KEY` со своими значениями:
+
+```bash
+export TELEGRAM_TOKEN=ВАШ_ТЕЛЕГРАМ_ТОКЕН
+export YANDEX_API_KEY=ВАШ_API_КЛЮЧ
+```
+
+4. Установите зависимости:
+
+```bash
+pip install python-telegram-bot requests
+```
+
+5. Запустите бота:
+
+```bash
+python bot.py
+```
+
+После запуска отправьте боту название города, и он ответит прогнозом погоды на неделю.
+
+## Создание deb-пакета
+
+Для сборки deb-пакета выполните:
+
+```bash
+bash build_deb.sh
+```
+
+Файл `build/telegram-weather-bot.deb` можно установить командой:
+
+```bash
+sudo dpkg -i build/telegram-weather-bot.deb
+```

--- a/bot.py
+++ b/bot.py
@@ -1,0 +1,69 @@
+import logging
+import os
+import requests
+from telegram import Update
+from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, filters, ContextTypes
+
+YANDEX_API_URL = "https://api.weather.yandex.ru/v2/forecast"
+YANDEX_API_KEY = os.getenv("YANDEX_API_KEY", "YOUR_YANDEX_API_KEY")
+
+TELEGRAM_TOKEN = os.getenv("TELEGRAM_TOKEN", "YOUR_TELEGRAM_BOT_TOKEN")
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+async def start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    await update.message.reply_text(
+        "Привет! Отправьте название города, и я пришлю прогноз погоды на неделю из Яндекс Погоды."
+    )
+
+
+def get_weather(city: str) -> str:
+    params = {
+        "geocode": city,
+        "lang": "ru_RU",
+        "limit": 7,
+        "hours": False,
+        "extra": False,
+    }
+    headers = {"X-Yandex-API-Key": YANDEX_API_KEY}
+    try:
+        response = requests.get(YANDEX_API_URL, params=params, headers=headers)
+        response.raise_for_status()
+        data = response.json()
+    except Exception as e:
+        logging.error("Failed to fetch weather: %s", e)
+        return "Не удалось получить данные о погоде."
+
+    if "forecasts" not in data:
+        return "Не удалось получить данные о погоде."
+
+    result_lines = [f"Прогноз погоды для {city}:"]
+    for day in data["forecasts"]:
+        date = day.get("date")
+        day_part = day.get("parts", {}).get("day", {})
+        condition = day_part.get("condition")
+        temp_min = day_part.get("temp_min")
+        temp_max = day_part.get("temp_max")
+        result_lines.append(f"{date}: {condition}, от {temp_min} до {temp_max} °C")
+    return "\n".join(result_lines)
+
+
+async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    city = update.message.text
+    weather = get_weather(city)
+    await update.message.reply_text(weather)
+
+
+def main() -> None:
+    application = ApplicationBuilder().token(TELEGRAM_TOKEN).build()
+
+    application.add_handler(CommandHandler("start", start))
+    application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+
+    application.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/build_deb.sh
+++ b/build_deb.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e
+PACKAGE=telegram-weather-bot
+VERSION=1.0
+BUILD_DIR=build/$PACKAGE
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR/DEBIAN"
+mkdir -p "$BUILD_DIR/usr/share/$PACKAGE"
+mkdir -p "$BUILD_DIR/usr/bin"
+
+cat > "$BUILD_DIR/DEBIAN/control" <<CONTROL
+Package: $PACKAGE
+Version: $VERSION
+Section: misc
+Priority: optional
+Architecture: all
+Depends: python3, python3-requests, python3-telegram
+Maintainer: Example <example@example.com>
+Description: Simple Telegram bot that shows weather forecast using Yandex Weather
+CONTROL
+
+install -m 644 bot.py "$BUILD_DIR/usr/share/$PACKAGE/bot.py"
+cat > "$BUILD_DIR/usr/bin/$PACKAGE" <<'WRAPPER'
+#!/bin/sh
+exec python3 /usr/share/telegram-weather-bot/bot.py "$@"
+WRAPPER
+chmod 755 "$BUILD_DIR/usr/bin/$PACKAGE"
+
+dpkg-deb --build "$BUILD_DIR" > /dev/null
+
+echo "Package created: $BUILD_DIR.deb"
+


### PR DESCRIPTION
## Summary
- add basic telegram bot fetching Yandex weather forecast in Russian
- update README with instructions on configuring API keys, installing dependencies, running the bot, and building a deb package
- add a script to build a deb package
- load tokens from environment variables in the bot code

## Testing
- `python -m py_compile bot.py`
- `bash build_deb.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855d5e29efc8320b9f7f8d38ea2d600